### PR TITLE
修复 setGlobalLogLevel 不影响新创建 logger 的问题

### DIFF
--- a/packages/core/src/Utils/Logger.ts
+++ b/packages/core/src/Utils/Logger.ts
@@ -287,9 +287,12 @@ export class LoggerManager {
     private static _instance: LoggerManager;
     private _loggers = new Map<string, ILogger>();
     private _defaultLogger: ILogger;
+    private _defaultLevel = LogLevel.Info;
 
     private constructor() {
-        this._defaultLogger = new ConsoleLogger();
+        this._defaultLogger = new ConsoleLogger({
+            level: this._defaultLevel,
+        });
     }
 
     /**
@@ -316,7 +319,7 @@ export class LoggerManager {
         if (!this._loggers.has(name)) {
             const logger = new ConsoleLogger({
                 prefix: name,
-                level: LogLevel.Info
+                level: this._defaultLevel,
             });
             this._loggers.set(name, logger);
         }
@@ -338,6 +341,8 @@ export class LoggerManager {
      * @param level 日志级别
      */
     public setGlobalLevel(level: LogLevel): void {
+        this._defaultLevel = level;
+
         if (this._defaultLogger instanceof ConsoleLogger) {
             this._defaultLogger.setLevel(level);
         }


### PR DESCRIPTION
## 问题描述
  `setGlobalLogLevel` 函数仅能修改已存在的 logger 实例的日志级别，但对后续新创建的 logger 实例无效。这不符合 "Global" 设置的预期行为，很多情况下都是需要先指定 Level 才创建实例，例如服务端，或者测试单元中。

## 根本原因
  在 `LoggerManager.getLogger()` 方法中，新创建的 logger 使用硬编码的 `LogLevel.Info`，不可配置。

## 解决方案
  1. 在 `LoggerManager` 中添加 `_defaultLevel` 字段存储全局默认日志级别
  2. 新创建的 logger 实例使用 `_defaultLevel` 而非硬编码值
  3. `setGlobalLevel` 方法同时更新 `_defaultLevel` 和所有已存在的 logger